### PR TITLE
feat: add `scanner.c` to rust and go bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Zig grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
 ## References
 
-- [Zig Grammar](https://github.com/ziglang/zig-spec/blob/master/grammar/grammar.y)
+- [Zig Grammar](https://github.com/ziglang/zig-spec/blob/master/grammar/grammar.peg)
 
 [ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter-grammars/tree-sitter-zig/ci.yml?logo=github&label=CI
 [discord]: https://img.shields.io/discord/1063097320771698699?logo=discord&label=discord

--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,6 +2,7 @@ package tree_sitter_zig
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
+// #include "../../src/scanner.c"
 import "C"
 
 import "unsafe"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -11,5 +11,9 @@ fn main() {
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+
     c_config.compile("tree-sitter-zig");
 }


### PR DESCRIPTION
@nik-rev, I got a linker error while trying to use the rust library of this PR version from my end. I noticed you have not included `scanner.c` in  `bindings/rust/build.rs`.